### PR TITLE
ME-51 Отключение отображения аватара для текущего игрока

### DIFF
--- a/Assets/ApplicationContent/AppAvatars/Scripts/AvatarSetups/PlayerAvatar.cs
+++ b/Assets/ApplicationContent/AppAvatars/Scripts/AvatarSetups/PlayerAvatar.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Global.Logger;
 using UnityEngine;
 
 namespace AppAvatars.AvatarSetups
@@ -98,6 +99,36 @@ namespace AppAvatars.AvatarSetups
             }
         }
 
+        /// <summary>
+        /// <para>Установить видимость аватара для главной камеры.</para>
+        /// </summary>
+        /// <param name="isVisible">true, если главная камера должна видеть данный аватар</param>
+        public void SetAvatarVisibility(bool isVisible)
+        {
+            if (!isPlayerSpawned)
+            {
+                AppLogger.Error($"Player avatar is not spawned yet.");
+                return;
+            }
+            
+            int layer = LayerMask.NameToLayer("Avatar");
+            if (!isVisible)
+            {
+                layer = LayerMask.NameToLayer("Not rendered");
+            }
+            
+            SetLayerRecursively(spawnedAvatar.gameObject, layer);
+        }
+        
+        private void SetLayerRecursively(GameObject obj, int layer)
+        {
+            obj.layer = layer;
+            foreach (Transform child in obj.transform)
+            {
+                SetLayerRecursively(child.gameObject, layer);
+            }
+        }
+        
         /// <summary>
         /// <para>Уничтожить аватар игрока.</para>
         /// </summary>

--- a/Assets/ApplicationContent/AppAvatars/Scripts/OfflineHumanoidPlayerAvatar.cs
+++ b/Assets/ApplicationContent/AppAvatars/Scripts/OfflineHumanoidPlayerAvatar.cs
@@ -1,3 +1,4 @@
+using AppAvatars.AvatarSetups;
 using Global.Logger;
 using NetworkCore.MirrorNetworking;
 using Player.EmbeddedPlayers;
@@ -34,7 +35,11 @@ namespace AppAvatars
                 
                 _playerAvatar.runtimeAnimatorController = _animatorController;
 
-                player.AvatarComponent.CreatePlayerFromAvatar(_playerAvatar);
+                PlayerAvatar avatarComponent = player.AvatarComponent;
+
+                avatarComponent.CreatePlayerFromAvatar(_playerAvatar);
+
+                avatarComponent.SetAvatarVisibility(false);
             }
         }
     }

--- a/Assets/ApplicationContent/NetworkCore/MirrorNetworking/Player/AvatarPlayer/NetworkAvatarPlayer.cs
+++ b/Assets/ApplicationContent/NetworkCore/MirrorNetworking/Player/AvatarPlayer/NetworkAvatarPlayer.cs
@@ -1,3 +1,4 @@
+using AppAvatars.AvatarSetups;
 using Global.Logger;
 using MainMenu.Containers;
 using Mirror;
@@ -53,10 +54,30 @@ namespace NetworkCore.MirrorNetworking.Player.AvatarPlayer
             NetworkDataStore networkStore = MVNetworkManager.singleton.NetworkStore;
             AvatarStore avatarStore = networkStore.Avatars;
             AvatarFile avatar = avatarStore.AvatarFiles[avatarName];
+            Animator prefab = avatar.Model.GetComponent<Animator>();
 
             AbstractPlayer player = Instantiate(networkStore.Player.CurrentBuildPlayer, transform, false);
+            PlayerAvatar avatarComponent = player.AvatarComponent;
 
-            Animator prefab = avatar.Model.GetComponent<Animator>();
+            AddAnimatorControllerToPrefab(avatar, avatarStore, ref prefab);
+
+            avatarComponent.CreatePlayerFromAvatar(prefab);
+
+            SetPlayerTransformSync(ref player);
+
+            SetAvatarVisibility(ref avatarComponent);
+
+            Animator spawnedAvatar = avatarComponent.SpawnedAvatar;
+
+            SetAvatarAnimationSync(ref spawnedAvatar);
+
+            SpawnNetworkDisplayName(networkStore, player);
+
+            PlayerController = player.PlayerController;
+        }
+
+        private static void AddAnimatorControllerToPrefab(AvatarFile avatar, AvatarStore avatarStore, ref Animator prefab)
+        {
             foreach (var controller in avatarStore.AnimatorControllers)
             {
                 if (controller.AnimationControllerType == avatar.AvatarAnimationControllerType)
@@ -65,22 +86,39 @@ namespace NetworkCore.MirrorNetworking.Player.AvatarPlayer
                     break;
                 }
             }
-     
-            player.AvatarComponent.CreatePlayerFromAvatar(prefab);
+        }
 
+        private void SetPlayerTransformSync(ref AbstractPlayer player)
+        {
             NetworkTransformReliable transformSync = GetComponent<NetworkTransformReliable>();
             transformSync.target = player.transform;
-            
-            Animator spawnedAvatar = player.AvatarComponent.SpawnedAvatar;
-            AnimatorParameterListener parameterListener = spawnedAvatar.gameObject.AddComponent<AnimatorParameterListener>();
+        }
+
+        private void SetAvatarVisibility(ref PlayerAvatar avatarComponent)
+        {
+            bool isCurrentPlayerAvatar = isClient && isLocalPlayer;
+            if (isCurrentPlayerAvatar)
+            {
+                avatarComponent.SetAvatarVisibility(false);
+            }
+            else
+            {
+                avatarComponent.SetAvatarVisibility(true);
+            }
+        }
+
+        private void SetAvatarAnimationSync(ref Animator spawnedAvatar)
+        {
+            AnimatorParameterListener parameterListener =gameObject.AddComponent<AnimatorParameterListener>();
             MVNetworkAnimator animatorSync = GetComponent<MVNetworkAnimator>();
             animatorSync.ParameterListener = parameterListener;
             animatorSync.ClientAuthority = true;
+        }
 
+        private void SpawnNetworkDisplayName(NetworkDataStore networkStore, AbstractPlayer player)
+        {
             NetworkPlayerDisplayName displayNameObject = Instantiate(networkStore.Player.DisplayName, player.transform, false);
             displayNameObject.NetworkPlayer = this;
-
-            PlayerController = player.PlayerController;
         }
     }
 }

--- a/Assets/ApplicationContent/Player/EmbeddedPlayers/PC/Prefabs/PCPlayer.prefab
+++ b/Assets/ApplicationContent/Player/EmbeddedPlayers/PC/Prefabs/PCPlayer.prefab
@@ -238,7 +238,7 @@ Camera:
   m_Depth: 0
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 247
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0
@@ -337,7 +337,7 @@ GameObject:
   - component: {fileID: 563657383539260756}
   - component: {fileID: 563657383539260763}
   - component: {fileID: 563657383539260762}
-  m_Layer: 7
+  m_Layer: 0
   m_Name: CharacterModel
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -13,7 +13,7 @@ TagManager:
   - UI
   - Player
   - Avatar
-  - 
+  - Not rendered
   - 
   - 
   - 


### PR DESCRIPTION
Dev:

- Добавлен Layer `Not rendered`. Объекты данного Layer не будут рендерится камерой префаба `PlayerPC`. В дальнейшем нужно у каждой камеры игрока убирать из Culling Mask данный слой
- В PlayerAvatar добавлен метод SetAvatarVisibility. Устанавливающий аватару Layer `Not rendered` либо `Avatar`, в зависимости от входного параметра
- В `NetworkAvatarPlayer` и `OfflineHumanoidPlayerAvatar` добавлена логика отключения видимости аватара игрока