### PR TITLE
ME-78 Корректная установка AnimatorParameterListener

### DIFF
--- a/Assets/ApplicationContent/NetworkCore/MirrorNetworking/Player/AvatarPlayer/NetworkAvatarPlayer.cs
+++ b/Assets/ApplicationContent/NetworkCore/MirrorNetworking/Player/AvatarPlayer/NetworkAvatarPlayer.cs
@@ -109,7 +109,7 @@ namespace NetworkCore.MirrorNetworking.Player.AvatarPlayer
 
         private void SetAvatarAnimationSync(ref Animator spawnedAvatar)
         {
-            AnimatorParameterListener parameterListener =gameObject.AddComponent<AnimatorParameterListener>();
+            AnimatorParameterListener parameterListener = spawnedAvatar.gameObject.AddComponent<AnimatorParameterListener>();
             MVNetworkAnimator animatorSync = GetComponent<MVNetworkAnimator>();
             animatorSync.ParameterListener = parameterListener;
             animatorSync.ClientAuthority = true;


### PR DESCRIPTION
Problem:

- При выносе добавления `AnimatorParameterListener` в отдельный метод, `AnimatorParameterListener` начал крепится на отдельный gameObject, а не на объект аватара

Fix:

- Прикреплять `AnimatorParameterListener` к аватару