### PR TITLE
ME-91 Игнорирование слоя Player Interactor-ом

### DIFF
--- a/Assets/LDR_SUAI_Metaverse_SDK/Core/Player/InteractorPC.cs
+++ b/Assets/LDR_SUAI_Metaverse_SDK/Core/Player/InteractorPC.cs
@@ -43,8 +43,11 @@ namespace LDR.SUAI_Metaverse.SDK.Core.Player
         private void CastInteractRay()
         {
             Ray ray = new Ray(_interactionRayStartPoint.position, _interactionRayStartPoint.forward);
-
-            bool hasHit = Physics.Raycast(ray, out RaycastHit hitInfo, _range);
+            
+            int playerLayer = LayerMask.NameToLayer("Player");
+            int mask = ~(1 << playerLayer);
+            
+            bool hasHit = Physics.Raycast(ray, out RaycastHit hitInfo,  _range, mask, QueryTriggerInteraction.Ignore);
 
             DrawDebugRay(hasHit, hitInfo, ray);
 


### PR DESCRIPTION
Problem:

- При определенной комплекции аватара, Inceractor может излучать луч изнутри CharacterController. Тогда он будет всегда упираться лучом взаимодействия в коллайдер CharacterController и другие взаимодействия ему будут недоступны

Fix:

- Интерактор должен игнорировать слой Player